### PR TITLE
Add an error message if key has no location data

### DIFF
--- a/GeoLocationCloud.php
+++ b/GeoLocationCloud.php
@@ -49,4 +49,11 @@ class GeoLocationCloud extends CloudEngine
             $this->dataKey = "location";
         }
     }
+
+    public function onRegistration($pipeline) {
+        if (!array_key_exists($this->dataKey, $pipeline->flowElementsList["cloud"]->flowElementProperties)) {
+            throw new \Exception("Location data was not available. Check that this key is authorised for geolocation data");
+        }
+        return parent::onRegistration($pipeline);
+    }
 }


### PR DESCRIPTION
Keys without permission to retrieve location data don't return anything, but the library assumes that they will return location data and so gives a misleading error message.
Alter LocationCloud to check for this in on_registration and give a more helpful error message.
This is also related to 51Degrees/location-node#2 and https://github.com/51Degrees/location-python/pull/1 and maybe a more general fix might apply to all.