### PR TITLE
Don't load the autoloader if we were loaded BY the autoloader

### DIFF
--- a/GeoLocationCloud.php
+++ b/GeoLocationCloud.php
@@ -23,7 +23,9 @@
 
 namespace fiftyone\pipeline\geolocation;
 
-require(__DIR__ . "/vendor/autoload.php");
+if(!class_exists("\Composer\Autoload\ClassLoader")) {
+  require(__DIR__ . "/vendor/autoload.php");
+}
 
 use fiftyone\pipeline\cloudrequestengine\CloudEngine;
 


### PR DESCRIPTION
The autoloader script only needs to be loaded once, and that should be done by the top-level script.
GeoLocationCloud.php tries to load it itself.
This works fine if the top level script is part of this library, because vendor/ will be in this directory.
However, if this whole library is itself installed from composer, then there will not be a vendor directory in this directory; instead, this directory will be in the top level vendor directory.
This means that using the library fails when it's installed from composer, with an error that looks like this:

`require(): Failed opening required '.../vendor/51degrees/fiftyone.geolocation/vendor/autoload.php' (include_path='.:/usr/share/php') in .../vendor/51degrees/fiftyone.geolocation/GeoLocationCloud.php on line 26`

We fix this by checking whether we were loaded from the autoloader; if we were (as we will be when we're a `composer require`-d library) then we don't load it ourselves.

An alternative fix would be to just drop that line entirely, as PR 2646 did in https://github.com/51Degrees/location-php/commit/b3f87fe420dac99fabcb682e72903939243fe5e1 and that may be preferred.