### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,5 +4,5 @@ This API complies with the `common-ci` approach.
 The following secrets are required:
 * `ACCESS_TOKEN` - GitHub [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens) for cloning repos, creating PRs, etc.
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=location-php&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`

--- a/examples/cloud/combiningservices.php
+++ b/examples/cloud/combiningservices.php
@@ -36,7 +36,7 @@
  * The resource key is used as short-hand to store the particular set of
  * properties you are interested in as well as any associated license keys
  * that entitle you to increased request limits and/or paid-for properties.
- * You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com/vHk79wZn).
+ * You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com/vHk79wZn?utm_source=code&utm_medium=example&utm_campaign=location-php&utm_content=examples-cloud-combiningservices.php&utm_term=header).
  * 
  * This example uses the 'Country' and 'IsMobile' properties, which are
  * pre-populated when creating a key using the link above.
@@ -72,7 +72,7 @@ if (substr($resourceKey, 0, 2) === "!!") {
     $message = 'No resource key specified in the environment variable ';
     $message .= '"' . Constants::RESOURCE_KEY_ENV_VAR . '"' . '<br/>';
     $message .= 'Create a resource key with the properties required by this example';
-    $message .= 'at https://configure.51degrees.com/vHk79wZn' . '<br/>';
+    $message .= 'at https://configure.51degrees.com/vHk79wZn?utm_source=code&utm_medium=example&utm_campaign=location-php&utm_content=examples-cloud-combiningservices.php&utm_term=resource-key-required' . '<br/>';
     $message .= 'Once complete, populate the environment variable ';
     $message .= 'mentioned at the start of this message with the key.' . '<br/>';
     echo $message;

--- a/examples/cloud/configurefromfile.php
+++ b/examples/cloud/configurefromfile.php
@@ -31,7 +31,7 @@
 * The resource key is used as short-hand to store the particular set of
 * properties you are interested in as well as any associated license keys
 * that entitle you to increased request limits and/or paid-for properties.
-* You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com/gGc3T5pT). 
+* You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com/gGc3T5pT?utm_source=code&utm_medium=example&utm_campaign=location-php&utm_content=examples-cloud-configurefromfile.php&utm_term=header). 
 * 
 * This example uses the 'Country' property, which is pre-populated 
 * when creating a key using the link above.
@@ -83,7 +83,7 @@ $configFileJSON = json_decode(file_get_contents($configFile), true);
 $resourceKey = $configFileJSON["PipelineOptions"]["Elements"][0]["BuildParameters"]["resourceKey"];
 if (substr($resourceKey, 0, 2) === "!!") {
     echo "You need to create a resource key at " .
-    "https://configure.51degrees.com/gGc3T5pT and paste it into " . 
+    "https://configure.51degrees.com/gGc3T5pT?utm_source=code&utm_medium=example&utm_campaign=location-php&utm_content=examples-cloud-configurefromfile.php&utm_term=resource-key-required and paste it into " . 
     "your config file, replacing !!YOUR_RESOURCE_KEY!!.";
     return;
 }

--- a/examples/cloud/gettingstarted.php
+++ b/examples/cloud/gettingstarted.php
@@ -32,7 +32,7 @@
  * The resource key is used as short-hand to store the particular set of
  * properties you are interested in as well as any associated license keys
  * that entitle you to increased request limits and/or paid-for properties.
- * You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com/gGc3T5pT).
+ * You can create a resource key using the 51Degrees [Configurator](https://configure.51degrees.com/gGc3T5pT?utm_source=code&utm_medium=example&utm_campaign=location-php&utm_content=examples-cloud-gettingstarted.php&utm_term=header).
  * 
  * This example uses the 'Country' property, which is pre-populated 
  * when creating a key using the link above.
@@ -65,7 +65,7 @@ if (substr($resourceKey, 0, 2) === "!!") {
     $message = 'No resource key specified in the environment variable ';
     $message .= '"' . Constants::RESOURCE_KEY_ENV_VAR . '"' . '<br/>';
     $message .= 'Create a resource key with the properties required by this example';
-    $message .= 'at https://configure.51degrees.com/gGc3T5pT' . '<br/>';
+    $message .= 'at https://configure.51degrees.com/gGc3T5pT?utm_source=code&utm_medium=example&utm_campaign=location-php&utm_content=examples-cloud-gettingstarted.php&utm_term=resource-key-required' . '<br/>';
     $message .= 'Once complete, populate the environment variable ';
     $message .= 'mentioned at the start of this message with the key.' . '<br/>';
     echo $message;
@@ -79,7 +79,7 @@ if (substr($resourceKey, 0, 2) === "!!") {
 // * The location provider: "digitalelement" or "fiftyonedegrees" 
 // (If digital element is used, you will need a resource key that allows you 
 // access to the appropriate property. You can do this via the following
-// link https://configure.51degrees.com/QMWqcX9n)
+// link https://configure.51degrees.com/QMWqcX9n?utm_source=code&utm_medium=example&utm_campaign=location-php&utm_content=examples-cloud-gettingstarted.php&utm_term=top)
 $settings = array(
     "resourceKey" => $resourceKey,
     "locationProvider" => "fiftyonedegrees"

--- a/examples/cloud/webIntegration.php
+++ b/examples/cloud/webIntegration.php
@@ -47,7 +47,7 @@ if (substr($resourceKey, 0, 2) === "!!") {
     $message = 'No resource key specified in the environment variable ';
     $message .= '"' . Constants::RESOURCE_KEY_ENV_VAR . '"' . '<br/>';
     $message .= 'Create a resource key with the properties required by this example';
-    $message .= 'at https://configure.51degrees.com/v399y42f' . '<br/>';
+    $message .= 'at https://configure.51degrees.com/v399y42f?utm_source=code&utm_medium=example&utm_campaign=location-php&utm_content=examples-cloud-webintegration.php&utm_term=resource-key-required' . '<br/>';
     $message .= 'Once complete, populate the environment variable ';
     $message .= 'mentioned at the start of this message with the key.' . '<br/>';
     $message .= "Make sure to include the Country, State, County, Town and ";

--- a/examples/index.php
+++ b/examples/index.php
@@ -34,7 +34,7 @@ $params = array(
 
 if ($params["resourceKey"] === "!!YOUR_RESOURCE_KEY!!") {
     $this->fail("You need to create a resource key at " .
-    "https://configure.51degrees.com and paste it into the " .
+    "https://configure.51degrees.com?utm_source=code&utm_medium=example&utm_campaign=location-php&utm_content=examples-index.php&utm_term=resource-key-required and paste it into the " .
     "phpunit.xml config file, " .
     "replacing !!YOUR_RESOURCE_KEY!!.");
 }

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees Geo-Location Engines
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=php-open-source "Data rewards the curious") **Pipeline API**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=location-php&utm_content=readme.md&utm_term=51degrees-geo-location-engines "Data rewards the curious") **Pipeline API**
 
-[Developer Documentation](https://51degrees.com/location-php/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=php-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/location-php/index.html?utm_source=github&utm_medium=readme&utm_campaign=location-php&utm_content=readme.md&utm_term=51degrees-geo-location-engines "developer documentation")
 
 ## Introduction
 
@@ -31,7 +31,7 @@ Make sure to select the latest version from [Composer.][composer]
 #### Configuration Options
 
  - String ``type`` - The name of the type of geolocation service to use.
- - String ``resourceKey`` - Resource Key is evidence used within the Cloud service for monitoring usage. [Obtain a resource key](https://configure.51degrees.com).
+ - String ``resourceKey`` - Resource Key is evidence used within the Cloud service for monitoring usage. [Obtain a resource key](https://configure.51degrees.com?utm_source=github&utm_medium=readme&utm_campaign=location-php&utm_content=readme.md&utm_term=configuration-options).
  - Array ``restrictedProperties`` - The properties to populate values for in the result (all are populated by default).
 
 ## Examples
@@ -69,5 +69,5 @@ To run the tests, then call:
 
 For complete documentation on the Pipeline API and associated engines, see the [51Degrees documentation site][Documentation].
 
-[Documentation]: https://51degrees.com/documentation/index.html
+[Documentation]: https://51degrees.com/documentation/index.html?utm_source=github&utm_medium=readme&utm_campaign=location-php&utm_content=readme.md&utm_term=project-documentation
 [composer]: https://packagist.org/packages/51degrees/fiftyone.geolocation


### PR DESCRIPTION
Tag navigational 51degrees.com and configure.51degrees.com links with the standard UTM vocabulary so the Content Team can trace traffic to its exact source. Replaces the old logo scheme (Logo.ashx -> /img/logo.png), normalises http/www/protocol-relative variants to https, and un-versions stale documentation paths. Adds a UTM link lint workflow.